### PR TITLE
feat: update web development offerings to focus on Vue.js

### DIFF
--- a/src/pages/consulting.astro
+++ b/src/pages/consulting.astro
@@ -183,17 +183,16 @@ const pageDescription =
 
           <!-- Service 3: Web Development -->
           <Card variant="white">
-            <h3 class="text-2xl font-bold text-navy mb-4">Blazor or React? Let's End the Debate.</h3>
+            <h3 class="text-2xl font-bold text-navy mb-4">Vue.js + .NET: A Powerful Combination</h3>
             <p class="text-gray-700 mb-4 leading-relaxed">
-              Whether you want full-stack Blazor or need a React SPA talking to a .NET API, I've
-              built production apps with both. I'll help you choose the right approach for your
-              team's skills and project needs.
+              Modern frontends deserve modern tooling. I build Vue 3 SPAs backed by ASP.NET Core
+              APIs — a clean separation that lets your frontend and backend teams move independently
+              while delivering seamless user experiences.
             </p>
 
             <h4 class="font-semibold text-navy mb-2">What I Help With:</h4>
             <ul class="list-disc list-inside text-gray-700 mb-4 space-y-1">
-              <li>Blazor application development</li>
-              <li>SPA + API architecture (React/Vue + ASP.NET Core)</li>
+              <li>Vue 3 SPA + ASP.NET Core API architecture</li>
               <li>Real-time features with SignalR</li>
               <li>Frontend performance optimization</li>
               <li>Team training on modern web stack</li>
@@ -201,7 +200,7 @@ const pageDescription =
 
             <h4 class="font-semibold text-navy mb-2">Technologies:</h4>
             <p class="text-sm text-gray-600">
-              Blazor, React, Vue.js, TypeScript, Tailwind CSS, SignalR, ASP.NET Core APIs
+              Vue 3, TypeScript, Tailwind CSS, SignalR, ASP.NET Core APIs
             </p>
           </Card>
 


### PR DESCRIPTION
## Summary
- Updates the Web Development service card on the consulting page to focus on Vue.js instead of offering Blazor and React
- Replaces "Blazor or React? Let's End the Debate." heading with "Vue.js + .NET: A Powerful Combination"
- Rewrites copy to emphasize Vue 3 SPAs backed by ASP.NET Core APIs
- Updates technologies list to highlight Vue 3, TypeScript, Tailwind CSS, SignalR, and ASP.NET Core APIs

## Test plan
- [ ] Run `npm run dev` and navigate to `/consulting`
- [ ] Verify the Web Development service card displays Vue.js-focused messaging
- [ ] Confirm no mentions of Blazor or React in the service offerings
- [ ] Run `npm run build` to verify successful build

🤖 Generated with [Claude Code](https://claude.ai/code)