### PR TITLE
Add Big Bear Mountain at Dollywood (credit #107)

### DIFF
--- a/src/content/blog/20260305-dapper-nvarchar-implicit-conversion-performance-trap.md
+++ b/src/content/blog/20260305-dapper-nvarchar-implicit-conversion-performance-trap.md
@@ -146,7 +146,7 @@ If you're using Dapper with SQL Server and your columns are `varchar`, go audit 
 
 If you're newer to Dapper, check out my introduction to [what Dapper is and why you should consider it](/what-is-dapper) for your .NET projects. And if you're building paginated queries, you might also like my article on [using COUNT(*) OVER() to get pagination counts in a single query](/sql-pagination-count-over-trick).
 
-Have you run into this one before? I'd love to hear your war stories — hit me up on [X](https://x.com/1kevgriff), [Bluesky](https://bsky.app/profile/1kevgriff.bsky.social), or [LinkedIn](https://www.linkedin.com/in/shortgriff/).
+Have you run into this one before? I'd love to hear your war stories — hit me up on [X](https://x.com/1kevgriff), [Bluesky](https://bsky.app/profile/consultwithgriff.com), or [LinkedIn](https://www.linkedin.com/in/1kevgriff/).
 
 ## Further Reading
 

--- a/src/content/docs/Coasters.md
+++ b/src/content/docs/Coasters.md
@@ -1,14 +1,14 @@
 ---
 title: Coaster Credits
 date: 2022-09-06 12:00:00
-updated: 2025-11-07 00:00:00
+updated: 2026-04-13 00:00:00
 permalink: coasters
 categories:
   - Roller Coasters
-excerpt: 'Explore my complete roller coaster credits list - 106 coasters across theme parks including Cedar Point, Kings Island, Dollywood, and more.'
+excerpt: 'Explore my complete roller coaster credits list - 107 coasters across theme parks including Cedar Point, Kings Island, Dollywood, and more.'
 ---
 
-Total Coaster Credits: 106
+Total Coaster Credits: 107
 
 ### Busch Gardens Williamsburg (Williamsburg, Virginia)
 
@@ -79,8 +79,9 @@ Total Coaster Credits: 106
 
 ### Dollywood (Pigeon Forge, Tennessee)
 
-8 Coasters
+9 Coasters
 
+- Big Bear Mountain
 - Lightning Rod
 - Blazing Fury
 - Wild Eagle


### PR DESCRIPTION
## Summary
- Added Big Bear Mountain to the Dollywood section of the coaster credits page
- Dollywood count updated from 8 → 9 coasters
- Total credits updated from 106 → 107

## Test plan
- [ ] Verify `/coasters` page renders correctly
- [ ] Confirm Big Bear Mountain appears under Dollywood
- [ ] Confirm total count shows 107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected social media link label in blog post
  * Enhanced coaster database: added new theme park attraction to Dollywood, increased total count to 107, and updated metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->