### PR TITLE
feat: add Link response headers for agent discovery (RFC 8288)

### DIFF
--- a/public/staticwebapp.config.json
+++ b/public/staticwebapp.config.json
@@ -41,7 +41,8 @@
     {
       "route": "/",
       "headers": {
-        "Cache-Control": "public, max-age=3600, must-revalidate"
+        "Cache-Control": "public, max-age=3600, must-revalidate",
+        "Link": "</llms.txt>; rel=\"describedby\"; type=\"text/markdown\", </rss.xml>; rel=\"alternate\"; type=\"application/rss+xml\"; title=\"Articles\", </sitemap-index.xml>; rel=\"sitemap\""
       }
     },
     { "route": "/sitemap.xml", "redirect": "/sitemap-index.xml", "statusCode": 301 },


### PR DESCRIPTION
## Summary

- Adds an HTTP `Link` header to the homepage in `public/staticwebapp.config.json` advertising agent-discoverable resources per RFC 8288 / RFC 9727.
- Points agents to three resources the site already serves: `/llms.txt` (`rel="describedby"`), `/rss.xml` (`rel="alternate"` with `application/rss+xml`), and `/sitemap-index.xml` (`rel="sitemap"`).
- Resolves the `isitagentready.com` discoverability check that flagged the homepage for having no `Link` headers.

Scoped to the `/` route only (not `globalHeaders`) to match the issue report and avoid emitting the header on asset/image responses where it's noise.

## Test plan

- [ ] After deploy, confirm the header is emitted: `curl -sI https://consultwithgriff.com/ | grep -i '^link:'`
- [ ] Re-run the check at `isitagentready.com` and confirm `checks.discoverability.linkHeaders.status` flips to `"pass"`
- [ ] Verify each advertised URL still resolves: `/llms.txt`, `/rss.xml`, `/sitemap-index.xml`
- [ ] Spot-check that existing security headers (`X-Content-Type-Options`, `X-Frame-Options`, etc.) and the homepage `Cache-Control` are unchanged

Note: local verification isn't possible — `staticwebapp.config.json` is only applied by the Azure SWA runtime, not by `npm run preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site configuration with HTTP Link headers advertising RSS feed, sitemap index, and description file availability. Improves content discoverability for search engines and feed readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->