### PR TITLE
fix: support Accept: text/markdown on the homepage

### DIFF
--- a/api/negotiate/index.js
+++ b/api/negotiate/index.js
@@ -49,6 +49,13 @@ function estimateTokens(text) {
   return String(Math.ceil(text.length / 4));
 }
 
+// Agent discovery links (RFC 8288). SWA doesn't propagate route-level headers
+// to responses from /api/* rewrites, so the function re-asserts them.
+const DISCOVERY_LINK =
+  '</llms.txt>; rel="describedby"; type="text/markdown", ' +
+  '</rss.xml>; rel="alternate"; type="application/rss+xml"; title="Articles", ' +
+  '</sitemap-index.xml>; rel="sitemap"';
+
 module.exports = async function (context, req) {
   const origin = resolveOrigin(req);
   const path = resolveOriginalPath(req);
@@ -67,6 +74,7 @@ module.exports = async function (context, req) {
             'Cache-Control': 'public, max-age=3600, must-revalidate',
             'X-Markdown-Tokens': estimateTokens(body),
             Vary: 'Accept',
+            Link: DISCOVERY_LINK,
           },
           body,
         };
@@ -87,6 +95,7 @@ module.exports = async function (context, req) {
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'public, max-age=3600, must-revalidate',
         Vary: 'Accept',
+        Link: DISCOVERY_LINK,
       },
       body,
     };

--- a/public/staticwebapp.config.json
+++ b/public/staticwebapp.config.json
@@ -21,6 +21,8 @@
     { "route": "/*.{woff,woff2,ttf,eot}", "headers": { "Cache-Control": "public, max-age=31536000, immutable" } },
     {
       "route": "/",
+      "methods": ["GET", "HEAD"],
+      "rewrite": "/api/negotiate",
       "headers": {
         "Cache-Control": "public, max-age=3600, must-revalidate",
         "Link": "</llms.txt>; rel=\"describedby\"; type=\"text/markdown\", </rss.xml>; rel=\"alternate\"; type=\"application/rss+xml\"; title=\"Articles\", </sitemap-index.xml>; rel=\"sitemap\""

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -1,0 +1,54 @@
+import type { APIContext } from 'astro';
+import { getCollection } from 'astro:content';
+
+export async function GET(_context: APIContext) {
+  const posts = await getCollection('blog');
+  const recent = posts
+    .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime())
+    .slice(0, 10);
+
+  const recentList = recent
+    .map((post) => {
+      const slug = post.data.permalink || post.id.replace(/^\d{8}-/, '');
+      const date = new Date(post.data.date).toISOString().split('T')[0];
+      return `- [${post.data.title}](https://consultwithgriff.com/${slug}) — ${date}`;
+    })
+    .join('\n');
+
+  const body = `---
+title: "Kevin W. Griffin — Azure & .NET Architect"
+canonical: https://consultwithgriff.com
+---
+
+# Kevin W. Griffin
+
+Independent software consultant specializing in ASP.NET Core, Microsoft Azure, and modern web development. 16-time Microsoft MVP.
+
+## Navigation
+
+- [About](https://consultwithgriff.com/about)
+- [Consulting](https://consultwithgriff.com/consulting)
+- [Articles](https://consultwithgriff.com/articles)
+- [Courses](https://consultwithgriff.com/courses)
+- [Contact](https://consultwithgriff.com/contact)
+
+## Agent-friendly resources
+
+- [llms.txt](https://consultwithgriff.com/llms.txt) — site summary for LLMs
+- [RSS feed](https://consultwithgriff.com/rss.xml)
+- [Sitemap](https://consultwithgriff.com/sitemap-index.xml)
+- Request \`Accept: text/markdown\` on any article URL, or append \`.md\` to the slug, to receive the markdown version.
+
+## Recent articles
+
+${recentList}
+
+See [/articles](https://consultwithgriff.com/articles) for the full archive.
+`;
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up to #232. The isitagentready.com scan tests the homepage URL with `Accept: text/markdown` and checks that the response is `text/markdown`. Our `/` route had its own entry (with only the Link headers, no rewrite), so the catch-all never fired and `/` always returned `text/html` regardless of Accept.

## Changes

- **`src/pages/index.md.ts`** — new Astro endpoint that generates `/index.md` at build time. Includes a site overview, navigation links, pointers to agent-friendly resources (llms.txt, RSS, sitemap, `.md` negotiation), and the 10 most recent articles.
- **`public/staticwebapp.config.json`** — add `rewrite: "/api/negotiate"` to the existing `/` route so the homepage flows through the content-negotiation function. The existing `Cache-Control` and `Link` headers on the route are preserved (SWA applies route headers regardless of rewrite).

## Test plan

- [ ] CI build passes and `/index.md` is present in `dist/`.
- [ ] After deploy, `curl -H "Accept: text/markdown" https://consultwithgriff.com/ -i` returns `content-type: text/markdown; charset=utf-8` with markdown body.
- [ ] `curl https://consultwithgriff.com/ -i` (no Accept override) still returns the HTML homepage.
- [ ] Homepage still advertises the Link headers (`rel="describedby"`, `rel="alternate"`, `rel="sitemap"`).
- [ ] Run the isitagentready.com scan and confirm `markdownNegotiation.status === "pass"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)