### PR TITLE
Add Flight of Fear at Kings Island

### DIFF
--- a/src/content/docs/Coasters.md
+++ b/src/content/docs/Coasters.md
@@ -1,14 +1,14 @@
 ---
 title: Coaster Credits
 date: 2022-09-06 12:00:00
-updated: 2026-04-13 00:00:00
+updated: 2026-05-04 00:00:00
 permalink: coasters
 categories:
   - Roller Coasters
-excerpt: 'Explore my complete roller coaster credits list - 107 coasters across theme parks including Cedar Point, Kings Island, Dollywood, and more.'
+excerpt: 'Explore my complete roller coaster credits list - 108 coasters across theme parks including Cedar Point, Kings Island, Dollywood, and more.'
 ---
 
-Total Coaster Credits: 107
+Total Coaster Credits: 108
 
 ### Busch Gardens Williamsburg (Williamsburg, Virginia)
 
@@ -191,7 +191,7 @@ Total Coaster Credits: 107
 
 ### Kings Island (Mason, Ohio)
 
-13 Coasters
+14 Coasters
 
 - The Beast (100th!)
 - Banshee
@@ -206,3 +206,4 @@ Total Coaster Credits: 107
 - Mystic Timbers
 - Snoopy's Soap Box Racers
 - Invertigo
+- Flight of Fear


### PR DESCRIPTION
## Summary
- Adds Flight of Fear to the Kings Island section of `src/content/docs/Coasters.md`
- Bumps Kings Island count from 13 to 14 and total credits from 107 to 108
- Updates `updated` date and excerpt count to match

## Test plan
- [ ] Verified each park section's declared count matches its list (script tally = 108)
- [ ] Confirmed Disneyland (Anaheim) count of 3 is intentional (no Gadget's Go Coaster, no DCA)
- [ ] `npm run build` should pass meta-description validation (excerpt length unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated coaster database with a new entry: Flight of Fear has been added to the Kings Island section, bringing the total coaster count from 107 to 108.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->