### PR TITLE
Fix 71 type errors from Astro 6 / Zod v4 upgrade

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -7,9 +7,7 @@ const URL_UNSAFE_CHARS = /[#?&]/;
 // Validator for URL-safe strings (tags/categories)
 const urlSafeString = z.string().refine(
   (val) => !URL_UNSAFE_CHARS.test(val),
-  (val) => ({
-    message: `"${val}" contains URL-unsafe characters (#, ?, &). Use slugified names like "csharp" instead of "C#".`,
-  })
+  { error: (issue) => `"${issue.input}" contains URL-unsafe characters (#, ?, &). Use slugified names like "csharp" instead of "C#".` }
 );
 
 // Blog collection - matches Gridsome frontmatter schema

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,29 +1,30 @@
 ---
 import { getCollection, render } from 'astro:content';
-import type { GetStaticPaths } from 'astro';
+import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import TableOfContents from '../components/TableOfContents.astro';
 import AuthorBio from '../components/AuthorBio.astro';
 import { slugify } from '../utils/slugify';
 
-export const getStaticPaths: GetStaticPaths = async () => {
+export const getStaticPaths = (async () => {
   const blogEntries = await getCollection('blog');
   const docsEntries = await getCollection('docs');
 
   const blogPaths = blogEntries.map((entry) => ({
     params: { slug: entry.data.permalink || entry.id.replace(/^\d{8}-/, '') },
-    props: { entry, type: 'blog' },
+    props: { entry, type: 'blog' as const },
   }));
 
   const docsPaths = docsEntries.map((entry) => ({
     params: { slug: entry.data.permalink || entry.id },
-    props: { entry, type: 'docs' },
+    props: { entry, type: 'docs' as const },
   }));
 
   return [...blogPaths, ...docsPaths];
-};
+}) satisfies GetStaticPaths;
 
-const { entry, type } = Astro.props;
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+const { entry, type } = Astro.props as Props;
 const { Content, headings, remarkPluginFrontmatter } = await render(entry);
 
 // Extract headings for TOC - Astro provides headings directly from render()
@@ -57,7 +58,7 @@ if (type === 'blog') {
   metaDescription =
     entry.data.description && entry.data.description.trim() !== ''
       ? entry.data.description
-      : entry.data.summary || entry.data.excerpt;
+      : entry.data.summary || entry.data.excerpt || '';
 } else {
   metaDescription = entry.data.excerpt || entry.data.title;
   // Use default OG image for docs pages

--- a/src/pages/article-categories/[category]/[...page].astro
+++ b/src/pages/article-categories/[category]/[...page].astro
@@ -1,10 +1,10 @@
 ---
 import { getCollection } from 'astro:content';
-import type { GetStaticPaths } from 'astro';
+import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { slugify } from '../../../utils/slugify';
 
-export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
+export const getStaticPaths = (async ({ paginate }) => {
   const allPosts = await getCollection('blog');
 
   // Get all unique categories
@@ -30,9 +30,10 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
   }
 
   return paths;
-};
+}) satisfies GetStaticPaths;
 
-const { page, originalCategory } = Astro.props;
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+const { page, originalCategory } = Astro.props as Props;
 const { category } = Astro.params;
 // Use original category for display, slugified version for URLs
 const displayCategory = originalCategory || category;

--- a/src/pages/article-tags/[tag]/[...page].astro
+++ b/src/pages/article-tags/[tag]/[...page].astro
@@ -1,10 +1,10 @@
 ---
 import { getCollection } from 'astro:content';
-import type { GetStaticPaths } from 'astro';
+import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { slugify } from '../../../utils/slugify';
 
-export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
+export const getStaticPaths = (async ({ paginate }) => {
   const allPosts = await getCollection('blog');
 
   // Get all unique tags
@@ -30,9 +30,10 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
   }
 
   return paths;
-};
+}) satisfies GetStaticPaths;
 
-const { page, originalTag } = Astro.props;
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+const { page, originalTag } = Astro.props as Props;
 const { tag } = Astro.params;
 // Use original tag for display, slugified version for URLs
 const displayTag = originalTag || tag;

--- a/src/pages/articles/[...page].astro
+++ b/src/pages/articles/[...page].astro
@@ -1,10 +1,10 @@
 ---
 import { getCollection } from 'astro:content';
-import type { GetStaticPaths } from 'astro';
+import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Card from '../../components/Card.astro';
 
-export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
+export const getStaticPaths = (async ({ paginate }) => {
   const allPosts = await getCollection('blog');
 
   // Sort posts by date descending
@@ -13,9 +13,10 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
   });
 
   return paginate(sortedPosts, { pageSize: 10 });
-};
+}) satisfies GetStaticPaths;
 
-const { page } = Astro.props;
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+const { page } = Astro.props as Props;
 const canonicalUrl =
   page.currentPage > 1
     ? `https://consultwithgriff.com/articles/${page.currentPage}`


### PR DESCRIPTION
## Summary

Cleans up 71 TypeScript errors left behind after the Astro 6 + Zod v4 upgrade (PR #235). Build and runtime were unaffected — these were type-checker-only failures.

Two root causes:

**1. Zod v4 `refine()` signature change (`src/content.config.ts`)**

Zod v4 no longer accepts a function as the second argument to `.refine()`. The old form:
```ts
z.string().refine(fn, (val) => ({ message: `"${val}" contains...` }))
```
Updated to the new object form using the `error` field, which accepts a function that receives the raw issue (with `issue.input` containing the failing value):
```ts
z.string().refine(fn, { error: (issue) => `"${issue.input}" contains...` })
```
Error message wording is preserved exactly.

**2. Astro 6 `getStaticPaths` prop type narrowing (~70 errors)**

Astro 6 tightened `Astro.props` types so that `getStaticPaths` functions annotated with `: GetStaticPaths` lost their specific return type — props came back as `unknown`. Switched all four affected page files to the `satisfies GetStaticPaths` + `InferGetStaticPropsType` pattern so TypeScript infers concrete prop shapes:

- `src/pages/articles/[...page].astro`
- `src/pages/article-tags/[tag]/[...page].astro`
- `src/pages/article-categories/[category]/[...page].astro`
- `src/pages/[slug].astro` — also marked `type` literals `as const` so the discriminated union narrows correctly between blog and docs entries; added `|| ''` fallback on `metaDescription` so the assignment resolves to `string` (no runtime behavior change since `summary` is a required field)

## Results

- `npm run type-check`: **0 errors** (was 71)
- `npm run build`: **418 pages built, Complete!** ✓

https://claude.ai/code/session_01JHap9juhLHYfKEgLht7iyy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHap9juhLHYfKEgLht7iyy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced URL validation error messages for clearer feedback when invalid characters are detected.
  * Improved blog post metadata handling with fallback support for alternative summary fields, ensuring better display when primary descriptions are unavailable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1kevgriff/ConsultWithGriff/pull/253)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->